### PR TITLE
Deloading Popup Fix

### DIFF
--- a/eventPage.js
+++ b/eventPage.js
@@ -1,26 +1,34 @@
 var _closedTimes = new Map();
 var _tabTimes = new Map();
 
-var _currentTabId = undefined;
-var _currentActivateTime = undefined;
+var _currentTabId = undefined; // the tabId for the current tab
+var _currentActivateTime = undefined; // the time the current tab was activated
 
 var _js_tabTimes = "";
 
-function tabTimes(tabId)
+function tabTimes(tabId, title, URL)
 {
+	this.name = title;
 	this.tabId = tabId;
+	this.URL = URL;
 	this.createTime = new Date();
 	this.elapsedTime = 0;
-	this.lastActiveTime = undefined;
+	this.lastActiveTime = undefined; // creation doesn't require activation
 }
 
+// _start(tab) initializes this event page to set the current 
+
+function start(tab)
+{
+	
+}
 
 
 // timestampTabCreation(tab) records the time of creation of tab into creationTimes
 
 function timestampTabCreation(tab)
 {
-	_tabTimes.set(tab.id, new tabTimes(tab.id));
+	_tabTimes.set(tab.id, new tabTimes(tab.id, tab.title, tab.URL));
 }
 
 
@@ -68,7 +76,8 @@ function removeTab(tabId, removeInfo)
 }
 
 
-// getTabTimes(item, key) returns a string containing the
+// getTabTimes(item, key) returns a string containing the open duration and open times of
+// _js_tabTimes
 
 function getTabTimes(tabTime, tabID, times)
 {
@@ -96,6 +105,7 @@ function onPopup(request, sender, sendResponse)
 // initialize all tabs into _tabTimes
 
 chrome.tabs.query({windowType: "normal"}, init);
+chrome.tabs.getCurrent(_start);
 
 
 // check for tab switches, creation, and deletion. Creation does not imply a tab switch.

--- a/popup.html
+++ b/popup.html
@@ -2,8 +2,13 @@
 <html>
 <head>
 <title>ClockedTabs Info</title>
-</head>
-<body>
 <script src="popup.js"></script>
+</head>
+<body style="width: 400px">
+<div id="stupidDiv">
+
+Loading...
+
+</div>
 </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,1 +1,15 @@
-chrome.windows.create({type: "normal", url: "tabTimes.html"});
+var tabText = "";
+
+function main()
+{
+	setTimeout(function(){
+	document.getElementById("stupidDiv").innerText = tabText;
+	}, 2000); // execute after chrome sends string back
+	chrome.runtime.sendMessage({times: "tabTimes"}, 
+	function(response)
+	{
+		tabText = tabText.concat(response);
+	});
+}
+
+window.onload = main;


### PR DESCRIPTION
Chrome's entire API is subject to a race condition, not freezing the
thread it was executed in. Fixed this with setting a timeout for
assigning the string from the message query to the API.
